### PR TITLE
Fix constant typo INVALID_ADDRESS_NUL_608

### DIFF
--- a/src/main/java/com/dragomitch/ipl/pae/business/exceptions/ErrorFormat.java
+++ b/src/main/java/com/dragomitch/ipl/pae/business/exceptions/ErrorFormat.java
@@ -79,7 +79,7 @@ public class ErrorFormat {
   public static final int INVALID_BIRTHDATE_NULL_604 = 604;
   public static final int INVALID_BIRTHDATE_605 = 605;
   public static final int INVALID_NATIONALITY_NULL_606 = 606;
-  public static final int INVALID_ADDRESS_NUL_608 = 608;
+  public static final int INVALID_ADDRESS_NULL_608 = 608;
   public static final int PHONE_NUMBER_MAX_LENGTH_OVERFLOW_609 = 609;
   public static final int INVALID_GENDER_610 = 610;
   public static final int INVALID_GENDER_VALUE_611 = 611;

--- a/src/main/java/com/dragomitch/ipl/pae/business/implementations/NominatedStudentImpl.java
+++ b/src/main/java/com/dragomitch/ipl/pae/business/implementations/NominatedStudentImpl.java
@@ -179,7 +179,7 @@ class NominatedStudentImpl extends UserImpl implements NominatedStudent {
       violations.add(ErrorFormat.MAX_LENGTH_COUNTRY_CODE_OVERFLOW_314);
     }
     if (!isAValidObject(address)) {
-      violations.add(ErrorFormat.INVALID_ADDRESS_NUL_608);
+      violations.add(ErrorFormat.INVALID_ADDRESS_NULL_608);
     }
     if (phoneNumber.length() > NominatedStudentDao.PHONE_NUMBER_MAX_LENGTH) {
       violations.add(ErrorFormat.PHONE_NUMBER_MAX_LENGTH_OVERFLOW_609);


### PR DESCRIPTION
## Summary
- fix typo for address null constant
- update usage in `NominatedStudentImpl`

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684fe67d00988328871e8ae576c6e159