### PR TITLE
Add AGENTS documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+---
+name: "Erasmus-Management-Application"
+description: "This repository contains a web application for managing Erasmus mobilities."
+category: "Fullstack Development"
+author: "Dragomitch"
+authorUrl: "https://github.com/Dragomitch"
+tags: ["Java", "Angular", "Web", "Maven", "GitHub", "CI/CD"]
+lastUpdated: "2025-06-16"
+---
+
+# Erasmus Management Application (EMA)
+
+## Project Overview
+
+The Erasmus Management Application (EMA) is a fullstack web platform used to handle Erasmus mobility processes. The repository contains a Spring Boot backend and an Angular frontend. Use the dedicated guidelines for each part when contributing.
+
+## Tech Stack
+
+List the main technologies and tools used in the project:
+
+- **Frontend**: Angular 20
+- **Backend**: Spring Boot 3 (Java 21)
+- **Database**: PostgreSQL
+- **Deployment**: Docker Compose
+- **Other Tools**: GitHub Actions, Maven, Node.js
+
+For detailed instructions, see the stack-specific guides:
+
+- [`backend/AGENTS.md`](backend/AGENTS.md) – Java backend
+- [`frontend/AGENTS.md`](frontend/AGENTS.md) – Angular frontend
+
+## Project Structure
+
+Describe the recommended project directory structure:
+
+```
+project-name/
+├── backend/
+├── frontend/
+├── SQLRessources/
+├── docker-compose.yml
+├── pom.xml
+└── README.md
+```
+
+## Development Guidelines
+
+Refer to the backend or frontend guides for language-specific details. General rules include:
+
+### Code Style
+
+- Use consistent formatting tools
+- Follow language-specific best practices
+- Keep code clean and readable
+
+### Naming Conventions
+
+- File naming: kebab-case for Angular files, camelCase for Java classes
+- Variable naming: camelCase
+- Function naming: camelCase
+- Class naming: PascalCase
+
+### Git Workflow
+
+- Branch naming conventions: `feature/<topic>` or `bugfix/<topic>`
+- Commit message format: `<type>: <short description>`
+- Pull Request process: open PRs against `master` with a clear summary
+
+## Environment Setup
+
+See the respective guides for setup requirements.
+
+## Core Feature Implementation
+
+Implementation details for each feature are explained in the stack-specific guides.
+
+## Testing Strategy
+
+Testing instructions vary between backend and frontend. Refer to the dedicated guides.
+
+## Deployment Guide
+
+The project is designed to run via Docker Compose. Each part has further notes in its own guide.
+
+## Performance Optimization
+
+Optimization techniques are described separately for the backend and frontend.
+
+## Security Considerations
+
+Security best practices are outlined in the backend and frontend guides.
+
+## Monitoring and Logging
+
+Monitoring and logging approaches are provided in the stack-specific guides.
+
+## Common Issues
+
+See the troubleshooting sections in each guide.
+
+## Reference Resources
+
+- [Official Documentation Link]
+- [Related Tutorials]
+- [Community Resources]
+- [Best Practices Guide]
+
+## Changelog
+
+### v1.0.0 (YYYY-MM-DD)
+
+- Initial release
+- Implemented basic features
+
+---
+
+**Note**: Consult the backend or frontend guides depending on which part of the project you are working on.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,208 @@
+---
+name: "Erasmus-Management-Application Backend"
+description: "Guidelines for the Spring Boot API."
+category: "Backend Development"
+author: "Dragomitch"
+authorUrl: "https://github.com/Dragomitch"
+tags: ["Java", "Spring Boot", "Maven", "PostgreSQL"]
+lastUpdated: "2025-06-16"
+---
+
+# EMA Backend Guide
+
+## Project Overview
+
+This document provides instructions for working on the Java backend of the Erasmus Management Application. The backend exposes a REST API built with Spring Boot and handles business logic, persistence and security.
+
+## Tech Stack
+
+List the main technologies and tools used in the project:
+
+- **Language**: Java 21
+- **Framework**: Spring Boot 3
+- **Database**: PostgreSQL
+- **Build Tool**: Maven
+- **Deployment**: Docker/Docker Compose
+- **Testing**: JUnit 4 with Spring Boot Test
+
+## Project Structure
+
+```
+backend/
+├── Dockerfile
+src/
+├── main/
+│   ├── java/
+│   ├── resources/
+│   └── webapp/
+└── test/java/
+pom.xml
+```
+
+## Development Guidelines
+
+### Code Style
+
+- Follow the Google Java Style Guide.
+- Use the Maven formatter plugin before committing.
+- Keep methods short and well-documented.
+
+### Naming Conventions
+
+- File naming: match the public class name.
+- Variable naming: camelCase.
+- Function naming: camelCase.
+- Class naming: PascalCase.
+
+### Git Workflow
+
+- Branch from `master` using `feature/` or `bugfix/` prefixes.
+- Write meaningful commit messages in English.
+- Open a Pull Request with a summary of changes and link issues when relevant.
+
+## Environment Setup
+
+### Development Requirements
+
+- Java 21
+- Maven 3.9+
+- A running PostgreSQL instance
+
+### Installation Steps
+
+```bash
+# 1. Clone the project
+git clone [repository-url]
+
+# 2. Build and run tests
+mvn verify
+
+# 3. Start the application (dev profile)
+mvn spring-boot:run
+```
+
+## Core Feature Implementation
+
+### Feature Module 1
+
+Business logic is organised in use case controllers located under `src/main/java/com/dragomitch/ipl/pae/uccontrollers`. Each controller exposes REST endpoints using Spring MVC annotations.
+
+```java
+// Example code
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+  @GetMapping
+  public List<UserDto> listUsers() {
+    // Implementation logic
+  }
+}
+```
+
+### Feature Module 2
+
+Persistence is handled with Spring Data JPA repositories found under `persistence`. Entities are mapped using standard JPA annotations.
+
+## Testing Strategy
+
+### Unit Testing
+
+- Testing framework: JUnit 4
+- Test coverage requirements: aim for 80%
+- Test file organization: mirror package structure under `src/test/java`
+
+### Integration Testing
+
+- Test scenarios: repository and controller integration
+- Testing tools: Spring Boot Test with an in-memory database
+
+### End-to-End Testing
+
+- Test workflow: executed via Docker Compose with the frontend
+- Automation tools: Maven profiles
+
+## Deployment Guide
+
+### Build Process
+
+```bash
+mvn clean package
+```
+
+### Deployment Steps
+
+1. Build the Docker image
+2. Configure environment variables
+3. Run `docker compose up backend`
+4. Verify the API is reachable on port 8080
+
+### Environment Variables
+
+```env
+DB_HOST=
+DB_PORT=
+DB_NAME=
+DB_USERNAME=
+DB_PASSWORD=
+```
+
+## Performance Optimization
+
+### Backend Optimization
+
+- Index frequently queried columns
+- Cache heavy computations when possible
+- Use connection pooling
+
+## Security Considerations
+
+### Data Security
+
+- Validate all input data
+- Use prepared statements to avoid SQL injection
+- Sanitize user-facing output
+
+### Authentication & Authorization
+
+- Spring Security manages authentication
+- Roles determine access to endpoints
+- JWT tokens are used for stateless sessions
+
+## Monitoring and Logging
+
+### Application Monitoring
+
+- Use Spring Boot Actuator for health checks
+- Track errors via logs
+- Optionally integrate with Prometheus/Grafana
+
+### Log Management
+
+- Log levels configured in `application.properties`
+- Use a rolling file appender
+- Store logs within the container or forward to a central system
+
+## Common Issues
+
+### Issue 1: Database connection failure
+
+**Solution**: Verify environment variables and ensure the PostgreSQL container is running.
+
+### Issue 2: Tests fail due to context loading
+
+**Solution**: Check that `application-test.properties` points to an in-memory database and that migrations run before tests.
+
+## Reference Resources
+
+- [Spring Boot Reference](https://docs.spring.io/spring-boot/docs/current/reference/html/)
+- [Maven Documentation](https://maven.apache.org/guides/index.html)
+- [PostgreSQL Documentation](https://www.postgresql.org/docs/)
+
+## Changelog
+
+### v1.0.0 (YYYY-MM-DD)
+
+- Initial backend release
+- Basic REST endpoints implemented
+
+---

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,196 @@
+---
+name: "Erasmus-Management-Application Frontend"
+description: "Guidelines for the Angular client."
+category: "Frontend Development"
+author: "Dragomitch"
+authorUrl: "https://github.com/Dragomitch"
+tags: ["Angular", "TypeScript", "Node.js"]
+lastUpdated: "2025-06-16"
+---
+
+# EMA Frontend Guide
+
+## Project Overview
+
+This document covers the development workflow for the Angular frontend of the Erasmus Management Application. The frontend consumes the REST API exposed by the backend and provides the user interface.
+
+## Tech Stack
+
+List the main technologies and tools used in the project:
+
+- **Framework**: Angular 20
+- **Language**: TypeScript
+- **Package Manager**: npm
+- **Styling**: CSS
+- **Testing**: Karma & Jasmine
+
+## Project Structure
+
+```
+frontend/
+├── src/
+│   ├── app/
+│   ├── assets/
+│   └── ...
+├── angular.json
+├── package.json
+├── tsconfig.json
+└── Dockerfile
+```
+
+## Development Guidelines
+
+### Code Style
+
+- Use the Angular CLI formatting tools (`ng lint`).
+- Prefer single quotes and end files with a newline.
+- Keep components small and focused.
+
+### Naming Conventions
+
+- File naming: kebab-case (`my-component.ts`).
+- Variable naming: camelCase.
+- Function naming: camelCase.
+- Class naming: PascalCase.
+
+### Git Workflow
+
+- Use `feature/` or `bugfix/` branches off `master`.
+- Commit messages follow `<type>: <short description>`.
+- Submit Pull Requests with screenshots for UI changes when possible.
+
+## Environment Setup
+
+### Development Requirements
+
+- Node.js 20+
+- npm 10+
+- Angular CLI 20
+
+### Installation Steps
+
+```bash
+# 1. Navigate to the frontend folder
+cd frontend
+
+# 2. Install dependencies
+npm install
+
+# 3. Start development server
+ng serve
+```
+
+## Core Feature Implementation
+
+### Feature Module 1
+
+Components are located under `src/app`. Services handle API calls via Angular's `HttpClient`.
+
+```typescript
+// Example code
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  constructor(private http: HttpClient) {}
+  getUsers() {
+    return this.http.get<User[]>('/api/users');
+  }
+}
+```
+
+### Feature Module 2
+
+Routing is defined in `app.routes.ts` using Angular's RouterModule. Guards can protect routes based on authentication state.
+
+## Testing Strategy
+
+### Unit Testing
+
+- Testing framework: Jasmine with Karma
+- Test coverage requirements: aim for 80%
+- Test file organization: mirror component structure with `*.spec.ts` files
+
+### Integration Testing
+
+- Test scenarios: component interaction with services
+- Testing tools: Angular TestBed
+
+### End-to-End Testing
+
+- Test workflow: run `ng e2e` using your preferred e2e framework
+- Automation tools: Protractor or Cypress
+
+## Deployment Guide
+
+### Build Process
+
+```bash
+ng build --configuration production
+```
+
+### Deployment Steps
+
+1. Build the Docker image
+2. Serve the static files via Nginx or the Node-based server
+3. Configure environment variables for API endpoints
+4. Verify the application loads on port 4200
+
+### Environment Variables
+
+```env
+API_URL=
+```
+
+## Performance Optimization
+
+### Frontend Optimization
+
+- Code splitting via lazy-loaded modules
+- Use Angular's `ChangeDetectionStrategy.OnPush` where appropriate
+- Cache HTTP responses
+
+## Security Considerations
+
+### Data Security
+
+- Validate user input on the client when possible
+- Escape dynamic content to avoid XSS
+
+### Authentication & Authorization
+
+- Tokens are stored in memory or session storage
+- Route guards enforce authorization rules
+
+## Monitoring and Logging
+
+### Application Monitoring
+
+- Use browser dev tools to track performance
+- Integrate with monitoring services if available
+
+### Log Management
+
+- Use `console.log` sparingly and remove debug statements in production builds
+
+## Common Issues
+
+### Issue 1: Dependency errors after a pull
+
+**Solution**: Delete `node_modules` and run `npm install` again.
+
+### Issue 2: API requests fail in development
+
+**Solution**: Check that the backend is running and `API_URL` is correctly configured.
+
+## Reference Resources
+
+- [Angular Documentation](https://angular.dev/docs)
+- [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/)
+
+## Changelog
+
+### v1.0.0 (YYYY-MM-DD)
+
+- Initial frontend release
+- Basic UI components implemented
+
+---


### PR DESCRIPTION
## Summary
- document general agent instructions and link to stack-specific guides
- add backend development guide
- add frontend development guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685052cf928c832890cb75ec4c349b2b