### PR TITLE
Fix CI Java version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '21'
       - run: mvn -B verify
 


### PR DESCRIPTION
## Summary
- use Java 21 in GitHub Actions workflow

## Testing
- `mvn -B verify`

------
https://chatgpt.com/codex/tasks/task_e_6858de1c0fec83289b5674fd9d0db510