### PR TITLE
Migrate tests to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/test/java/business/TestCountry.java
+++ b/test/java/business/TestCountry.java
@@ -1,6 +1,6 @@
 package java.business;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.dragomitch.ipl.pae.business.EntityFactory;
 import com.dragomitch.ipl.pae.business.dto.CountryDto;
@@ -8,9 +8,9 @@ import com.dragomitch.ipl.pae.business.dto.ProgrammeDto;
 import com.dragomitch.ipl.pae.context.ContextManager;
 import com.dragomitch.ipl.pae.context.DependencyManager;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestCountry {
 
@@ -21,7 +21,7 @@ public class TestCountry {
   private EntityFactory entityFactory;
   private CountryDto country;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     ContextManager.loadContext(ContextManager.ENV_TEST);
   }
@@ -29,7 +29,7 @@ public class TestCountry {
   /**
    * Creates a new Country instance.
    */
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     entityFactory = DependencyManager.getInstance(EntityFactory.class);
     this.country = (CountryDto) entityFactory.build(CountryDto.class);

--- a/test/java/com/dragomitch/ipl/pae/ApplicationTests.java
+++ b/test/java/com/dragomitch/ipl/pae/ApplicationTests.java
@@ -1,11 +1,15 @@
 package com.dragomitch.ipl.pae;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 class ApplicationTests {
   @Test
   void contextLoads() {
   }
 }
+


### PR DESCRIPTION
## Summary
- drop the junit-vintage engine
- use `SpringExtension` in `ApplicationTests`
- convert `TestCountry` to JUnit Jupiter

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6858dd9ffd0c83289b1d1df2bc28845d